### PR TITLE
changed uglify options

### DIFF
--- a/webpack/base.config.js
+++ b/webpack/base.config.js
@@ -15,9 +15,13 @@ const baseConfig = ({ input, output = {}, globals = {}, plugins, loaders }) => (
       new webpack.optimize.DedupePlugin(),
       new webpack.optimize.UglifyJsPlugin({
         comments: false,
-        compressor: {
+        compress: {
           warnings: false
-        }
+        },
+         output: {
+                    ascii_only: true,
+                    beautify: false,
+            }
       })
     ])
   ],


### PR DESCRIPTION
2 changes here:  

1. i think `compressor` should be `compress`. i'm not sure if both work or not, but the (webpack docs)[http://webpack.github.io/docs/list-of-plugins.html#uglifyjsplugin] say `compress`

2. `UglifyJS` unescapes `\u0000` and other unicode char code strings and converts them . this results in some libraries (`eg, `js-base64`, `firebase`) getting screwed up, and Chrome refusing to load the extension b/c the `injection` isn't `utf-8`. 

i hit that problem today and have been researching it. i could be wrong, but wanted to put in a PR to see what you thought

there's a `couchDB` bug that briefly explains it [here](https://github.com/pouchdb/pouchdb/issues/5798)

the post that discusses the solution is on the `uglify` [repo here](https://github.com/mishoo/UglifyJS2/issues/490)